### PR TITLE
feat(mvp): providers registry + jobs api + supabase schema

### DIFF
--- a/api/jobs/[id].ts
+++ b/api/jobs/[id].ts
@@ -1,0 +1,60 @@
+import { createClient } from '@supabase/supabase-js';
+import { json } from '../integrations/_shared';
+import type { JobRow } from '../../providers/types';
+import { pollProviderJob } from '../../services/providerClients';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function supabaseAdmin() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+}
+
+function getIdFromUrl(req: Request): string | null {
+  try {
+    const url = new URL(req.url);
+    const parts = url.pathname.split('/').filter(Boolean);
+    return parts[parts.length - 1] || null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: Request) {
+  if (req.method !== 'GET') return json({ error: 'method_not_allowed' }, { status: 405 });
+
+  try {
+    const id = getIdFromUrl(req);
+    if (!id) return json({ error: 'missing_id' }, { status: 400 });
+
+    const sb = supabaseAdmin();
+
+    const { data: job, error } = await sb.from('jobs').select('*').eq('id', id).single();
+    if (error) return json({ error: error.message }, { status: 404 });
+
+    const row = job as JobRow;
+    if (row.status === 'running' && row.provider_job_id) {
+      const polled = await pollProviderJob(row.provider_id, row.provider_job_id);
+      const progress = typeof polled.progress === 'number' ? polled.progress : row.progress;
+
+      // For MVP stub we don't produce output.
+      const newStatus = polled.status === 'succeeded' ? 'succeeded' : polled.status === 'failed' ? 'failed' : 'running';
+
+      const { data: updated } = await sb
+        .from('jobs')
+        .update({ status: newStatus, progress, error: polled.error || null, updated_at: new Date().toISOString() })
+        .eq('id', id)
+        .select('*')
+        .single();
+
+      return json({ job: (updated as JobRow) || row });
+    }
+
+    return json({ job: row });
+  } catch (e: any) {
+    return json({ error: e?.message || 'server_error' }, { status: 500 });
+  }
+}

--- a/api/jobs/index.ts
+++ b/api/jobs/index.ts
@@ -1,0 +1,65 @@
+import { createClient } from '@supabase/supabase-js';
+import { json } from '../integrations/_shared';
+import type { CreateJobRequest, JobRow } from '../../providers/types';
+import { startProviderJob } from '../../services/providerClients';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function supabaseAdmin() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+}
+
+export default async function handler(req: Request) {
+  if (req.method !== 'POST') return json({ error: 'method_not_allowed' }, { status: 405 });
+
+  try {
+    const body = (await req.json()) as CreateJobRequest;
+    if (!body?.type || !body?.request?.provider_id || !body?.request?.mode) {
+      return json({ error: 'missing_fields' }, { status: 400 });
+    }
+
+    const sb = supabaseAdmin();
+
+    const jobId = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    // Create job as queued
+    const insertPayload = {
+      id: jobId,
+      type: body.type,
+      status: 'queued',
+      provider_id: body.request.provider_id,
+      mode: body.request.mode,
+      request: body.request,
+      provider_job_id: null,
+      output_asset_id: null,
+      error: null,
+      progress: null,
+      created_at: now,
+      updated_at: now,
+    };
+
+    const { error: insErr } = await sb.from('jobs').insert(insertPayload);
+    if (insErr) return json({ error: insErr.message }, { status: 500 });
+
+    // Start provider job
+    const start = await startProviderJob(body.request);
+
+    const { data: updated, error: updErr } = await sb
+      .from('jobs')
+      .update({ status: 'running', provider_job_id: start.provider_job_id, updated_at: new Date().toISOString() })
+      .eq('id', jobId)
+      .select('*')
+      .single();
+
+    if (updErr) return json({ error: updErr.message }, { status: 500 });
+
+    return json({ job: updated as JobRow });
+  } catch (e: any) {
+    return json({ error: e?.message || 'server_error' }, { status: 500 });
+  }
+}

--- a/api/providers.ts
+++ b/api/providers.ts
@@ -1,0 +1,13 @@
+import { json } from './integrations/_shared';
+import { listProviders } from '../providers/registry';
+
+export default async function handler(req: Request) {
+  if (req.method !== 'GET') return json({ error: 'method_not_allowed' }, { status: 405 });
+
+  try {
+    const providers = await listProviders();
+    return json({ providers });
+  } catch (e: any) {
+    return json({ error: e?.message || 'server_error' }, { status: 500 });
+  }
+}

--- a/providers/registry.ts
+++ b/providers/registry.ts
@@ -1,0 +1,24 @@
+import type { ProviderCapability, ProviderId, ProviderPublic } from './types';
+import { getEnabledIntegrations } from '../services/integrationsService';
+
+const DEFAULT_CAPS: Record<string, ProviderCapability[]> = {
+  heygen: ['talking_head'],
+  veo: ['image_to_video'],
+  sora: ['image_to_video', 'face_swap', 'character_swap'],
+};
+
+export async function listProviders(): Promise<ProviderPublic[]> {
+  const integrations = await getEnabledIntegrations();
+
+  return integrations.map((i) => {
+    const caps = (i.capabilities?.length ? i.capabilities : DEFAULT_CAPS[i.provider_id]) || [];
+
+    return {
+      provider_id: i.provider_id as ProviderId,
+      name: i.name || i.provider_id,
+      enabled: !!i.enabled,
+      status: i.enabled ? 'enabled' : 'disabled',
+      capabilities: caps,
+    } satisfies ProviderPublic;
+  });
+}

--- a/providers/types.ts
+++ b/providers/types.ts
@@ -1,0 +1,54 @@
+export type ProviderId = 'heygen' | 'veo' | 'sora' | (string & {});
+
+export type ProviderCapability =
+  | 'talking_head'
+  | 'image_to_video'
+  | 'face_swap'
+  | 'character_swap';
+
+export type ProviderStatus = 'enabled' | 'disabled' | 'misconfigured';
+
+export interface ProviderPublic {
+  provider_id: ProviderId;
+  name: string;
+  enabled: boolean;
+  status: ProviderStatus;
+  capabilities: ProviderCapability[];
+}
+
+export type JobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled';
+
+export type JobType = 'generate_video';
+
+export interface GenerateVideoRequest {
+  provider_id: ProviderId;
+  mode: ProviderCapability;
+  prompt?: string;
+  script?: string;
+  aspect_ratio?: '9:16' | '16:9' | '1:1' | string;
+  duration_seconds?: number;
+  input_image_asset_id?: string;
+  input_video_asset_id?: string;
+  avatar_id?: string;
+  options?: Record<string, unknown>;
+}
+
+export interface CreateJobRequest {
+  type: JobType;
+  request: GenerateVideoRequest;
+}
+
+export interface JobRow {
+  id: string;
+  type: JobType;
+  status: JobStatus;
+  provider_id: ProviderId;
+  mode: ProviderCapability;
+  request: Record<string, unknown>;
+  provider_job_id: string | null;
+  output_asset_id: string | null;
+  error: string | null;
+  progress: number | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/services/integrationsService.ts
+++ b/services/integrationsService.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+function supabaseAdmin() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false },
+  });
+}
+
+export type IntegrationRow = {
+  id: string;
+  provider_id: string;
+  name: string;
+  enabled: boolean;
+  base_url: string | null;
+  capabilities: string[] | null;
+  config: Record<string, unknown> | null;
+  secret_enc: string | null;
+  updated_at: string;
+};
+
+export async function getEnabledIntegrations(): Promise<IntegrationRow[]> {
+  const sb = supabaseAdmin();
+  const { data, error } = await sb
+    .from('integrations')
+    .select('id, provider_id, name, enabled, base_url, capabilities, config, secret_enc, updated_at')
+    .eq('enabled', true)
+    .order('updated_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data as IntegrationRow[]) || [];
+}
+
+export async function getIntegrationByProvider(provider_id: string): Promise<IntegrationRow | null> {
+  const sb = supabaseAdmin();
+  const { data, error } = await sb
+    .from('integrations')
+    .select('id, provider_id, name, enabled, base_url, capabilities, config, secret_enc, updated_at')
+    .eq('provider_id', provider_id)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return (data as IntegrationRow) || null;
+}

--- a/services/providerClients.ts
+++ b/services/providerClients.ts
@@ -1,0 +1,48 @@
+import type { GenerateVideoRequest } from '../providers/types';
+import { getIntegrationByProvider } from './integrationsService';
+
+export type ProviderJobStartResult = { provider_job_id: string };
+export type ProviderJobStatusResult = {
+  status: 'running' | 'succeeded' | 'failed';
+  progress?: number;
+  output_url?: string;
+  error?: string;
+};
+
+function decodeSecret(secret_enc: string | null): string | null {
+  if (!secret_enc) return null;
+  try {
+    return Buffer.from(secret_enc, 'base64').toString('utf-8');
+  } catch {
+    return null;
+  }
+}
+
+async function assertEnabled(provider_id: string) {
+  const integ = await getIntegrationByProvider(provider_id);
+  if (!integ || !integ.enabled) {
+    throw new Error(`Provider disabled or missing: ${provider_id}`);
+  }
+  return integ;
+}
+
+export async function startProviderJob(req: GenerateVideoRequest): Promise<ProviderJobStartResult> {
+  const integ = await assertEnabled(req.provider_id);
+  const apiKey = decodeSecret(integ.secret_enc);
+
+  // MVP: we don't call real providers here. This is a safe placeholder.
+  // You will add official endpoints + auth later.
+  if (!apiKey) {
+    // Still allow creating a job but mark it as failed immediately by throwing.
+    throw new Error(`Missing API key for provider: ${req.provider_id}`);
+  }
+
+  // Return a synthetic provider job id for now.
+  return { provider_job_id: `stub_${req.provider_id}_${crypto.randomUUID()}` };
+}
+
+export async function pollProviderJob(provider_id: string, provider_job_id: string): Promise<ProviderJobStatusResult> {
+  await assertEnabled(provider_id);
+  // MVP stub: always running.
+  return { status: 'running', progress: 10 };
+}

--- a/supabase_migration_mvp_jobs_assets_avatars.sql
+++ b/supabase_migration_mvp_jobs_assets_avatars.sql
@@ -1,0 +1,56 @@
+-- MVP schema additions: integrations (extensions), jobs, assets, avatars
+
+-- Integrations table extension
+alter table if exists public.integrations
+  add column if not exists provider_id text;
+
+alter table if exists public.integrations
+  add column if not exists enabled boolean not null default false;
+
+alter table if exists public.integrations
+  add column if not exists base_url text;
+
+alter table if exists public.integrations
+  add column if not exists capabilities text[];
+
+-- keep existing columns: auth_type, name, config, secret_enc, is_active etc.
+
+create table if not exists public.assets (
+  id uuid primary key,
+  kind text not null check (kind in ('image','video','audio')),
+  bucket text,
+  path text,
+  public_url text,
+  meta jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.avatars (
+  id uuid primary key,
+  name text not null,
+  primary_image_asset_id uuid references public.assets(id),
+  meta jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.jobs (
+  id uuid primary key,
+  type text not null,
+  status text not null,
+  provider_id text not null,
+  mode text not null,
+  request jsonb not null default '{}'::jsonb,
+  provider_job_id text,
+  output_asset_id uuid references public.assets(id),
+  error text,
+  progress int,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists jobs_status_idx on public.jobs(status);
+create index if not exists jobs_provider_idx on public.jobs(provider_id);
+
+-- NOTE: RLS policies intentionally omitted for "only for me" MVP.
+-- If you later add Supabase Auth, enable RLS and add policies.


### PR DESCRIPTION
Adds MVP scaffolding:
- Provider registry sourced from Supabase `integrations` (enabled/capabilities)
- Jobs create/poll API (server-side) using Supabase `jobs`
- SQL migration to add `jobs`, `assets`, `avatars` and extend `integrations`

Notes:
- Provider calls are stubbed intentionally (you will add official endpoints and keys).
- No destructive changes; RLS omitted for personal-use MVP.

Commit: 470a8b988ff276da2f4da3c9e284cdc4dc80fba1